### PR TITLE
Add missing properties in fusion

### DIFF
--- a/Resources/Private/Fusion/Map/StaticMap.fusion
+++ b/Resources/Private/Fusion/Map/StaticMap.fusion
@@ -5,6 +5,8 @@ prototype(Jonnitto.GoogleMaps:StaticMap) < prototype(Neos.Fusion:Tag) {
 
     mapLocation = ${String.rawUrlEncode(String.trim(q(node).property('mapLocation')))}
     zoom = ${String.rawUrlEncode(q(node).property('zoom'))}
+    height = ${String.rawUrlEncode(q(node).property('height'))}
+    width = ${String.rawUrlEncode(q(node).property('width'))}
     scale = ${String.rawUrlEncode(q(node).property('scale'))}
 
     maptype = ${String.rawUrlEncode(q(node).property('maptype'))}


### PR DESCRIPTION
Add missing height and width properties in fusion. If they are missing the URL `size={width}x{height}` is rendering `size=x` which leads to the error: _"The Google Maps Platform server rejected your request. Invalid request. Invalid 'size' parameter."_